### PR TITLE
Add prefix format string as config parameter

### DIFF
--- a/src/main/kotlin/org/nemwiz/jiracommitmessage/configuration/PluginSettingsConfiguration.kt
+++ b/src/main/kotlin/org/nemwiz/jiracommitmessage/configuration/PluginSettingsConfiguration.kt
@@ -16,11 +16,13 @@ class PluginSettingsConfiguration : Configurable {
 
     override fun isModified(): Boolean {
         return pluginSettingsConfigurationPanel.jiraProjectPrefixField.text !=
-            pluginSettingsState.jiraProjectPrefix
+            pluginSettingsState.jiraProjectPrefix || pluginSettingsConfigurationPanel.commitPrefixFormatField.text !=
+            pluginSettingsState.commitPrefixFormat
     }
 
     override fun apply() {
         pluginSettingsState.jiraProjectPrefix = pluginSettingsConfigurationPanel.jiraProjectPrefixField.text
+        pluginSettingsState.commitPrefixFormat = pluginSettingsConfigurationPanel.commitPrefixFormatField.text
     }
 
     override fun getDisplayName(): String {
@@ -33,5 +35,6 @@ class PluginSettingsConfiguration : Configurable {
 
     override fun reset() {
         pluginSettingsConfigurationPanel.jiraProjectPrefixField.text = pluginSettingsState.jiraProjectPrefix
+        pluginSettingsConfigurationPanel.commitPrefixFormatField.text = pluginSettingsState.commitPrefixFormat
     }
 }

--- a/src/main/kotlin/org/nemwiz/jiracommitmessage/configuration/PluginSettingsConfigurationPanel.kt
+++ b/src/main/kotlin/org/nemwiz/jiracommitmessage/configuration/PluginSettingsConfigurationPanel.kt
@@ -10,10 +10,12 @@ class PluginSettingsConfigurationPanel {
 
     var mainPanel: JPanel
     var jiraProjectPrefixField: JBTextField = JBTextField()
+    var commitPrefixFormatField: JBTextField = JBTextField()
 
     init {
         mainPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel("JIRA project prefix "), jiraProjectPrefixField, 1, false)
+            .addLabeledComponent(JBLabel("Commit prefix format "), commitPrefixFormatField, 1, false)
             .addComponentFillVertically(JPanel(), 0)
             .panel
     }

--- a/src/main/kotlin/org/nemwiz/jiracommitmessage/configuration/PluginSettingsState.kt
+++ b/src/main/kotlin/org/nemwiz/jiracommitmessage/configuration/PluginSettingsState.kt
@@ -25,6 +25,7 @@ class PluginSettingsState : PersistentStateComponent<PluginSettingsState.PluginS
     }
 
     class PluginState {
-        var jiraProjectPrefix = ""
+        var jiraProjectPrefix = "(%s) "
+        var commitPrefixFormat = ""
     }
 }

--- a/src/main/kotlin/org/nemwiz/jiracommitmessage/services/MyProjectService.kt
+++ b/src/main/kotlin/org/nemwiz/jiracommitmessage/services/MyProjectService.kt
@@ -11,13 +11,14 @@ class MyProjectService(private val project: Project) {
 
     fun getTaskIdFromBranchName(): String? {
         val jiraProjectPrefix = PluginSettingsState.instance.state.jiraProjectPrefix
+        val commitPrefixFormat = PluginSettingsState.instance.state.commitPrefixFormat
         val repositoryManager = getRepositoryManager(project)
         val branch = repositoryManager.repositories[0].currentBranch
         val matcher = branch?.let { matchBranchNameThroughRegex(jiraProjectPrefix, it) }
 
         return matcher?.let {
             return if (matcher.find()) {
-                String.format("(%s)", matcher.group(0))
+                String.format(commitPrefixFormat, matcher.group(0))
             } else {
                 ""
             }


### PR DESCRIPTION
Hi!
Great plugin! I had the need to customise the commit comment prefix so I added the format string as a configuration parameter. It also meets the need of gesundes in issue #3 . Please merge if you find it useful.

Best regards
almegren