### PR TITLE
Feat/add support for multi repository projects

### DIFF
--- a/src/main/kotlin/org/nemwiz/jiracommitmessage/provider/PluginProvider.kt
+++ b/src/main/kotlin/org/nemwiz/jiracommitmessage/provider/PluginProvider.kt
@@ -20,11 +20,14 @@ class PluginProvider : CommitMessageProvider {
         val plugin = project.service<JiraCommitMessagePlugin>()
 
         val repositoryManager = GitUtil.getRepositoryManager(project)
-        val branch = repositoryManager.repositories[0].currentBranch
 
-        LOG.info("JIRA Commit message plugin provider - branch -> $branch")
+        val changes = forChangelist.changes
 
-        val newCommitMessage = plugin.getCommitMessageFromBranchName(branch?.name)
+        val branchName = plugin.extractBranchNameFromChanges(changes, repositoryManager)
+
+        LOG.info("JIRA Commit message plugin provider - branch -> $branchName")
+
+        val newCommitMessage = plugin.getCommitMessageFromBranchName(branchName)
 
         return if (newCommitMessage == "") {
             oldCommitMessage

--- a/src/main/kotlin/org/nemwiz/jiracommitmessage/services/JiraCommitMessagePlugin.kt
+++ b/src/main/kotlin/org/nemwiz/jiracommitmessage/services/JiraCommitMessagePlugin.kt
@@ -78,7 +78,10 @@ class JiraCommitMessagePlugin(private val project: Project) : Disposable {
             }
         }
         val changesInRepositories = repositoriesChanged.groupingBy { it }. eachCount().toList().sortedBy { (_, value) -> value }
-        var branchName = repositoryManager.repositories[0].currentBranch?.name
+        var branchName: String? = null
+        if (repositoryManager.repositories.isNotEmpty()) {
+            branchName = repositoryManager.repositories[0]?.currentBranch?.name
+        }
         for (changesInRepository in changesInRepositories) {
             val currentBranch = changesInRepository.first.currentBranch ?: continue
             val jiraIssue = extractJiraIssueFromBranch(currentBranch.name) ?: continue


### PR DESCRIPTION
Hi! I wanted to use this plugin in a project that has multiple git repositories. Not every repository had a branch with a jira issue key in it. This plugin always takes the first repository, so sadly this plugin did not work for me.

I've now added support for having multiple repositories in one project.

The new behaviour is as follows:

If the action button is pressed it will sort all repositories by the amount of changes made or the amount of selected changes for the commit.
Then it will iterate through the repositories. In the end it will use the repository that has the most changes AND has a jira issue key. If it can't find a suitable repository it will fallback to the previous behaviour of using the first one.

When a new branch is checked out the behaviour is unchanged.

I have never touched intellij plugins before, so any feedback is welcome!